### PR TITLE
Automatic synthesis of STEP policy upon instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Having decided an appropriate form for the risk budget shape, policy synthesis i
 $ python scripts/synthesize_general_step_policy.py -n {n_max} -a {alpha} -pz {shape_parameter} -up {use_p_norm}
 ```
 
+Note: This script will be called automatically upon instantiation of a test object, if the corresponding polciy file is missing from `sequentialized_barnard_tests/policies/`.
+
 ### (2B) What If I Don't Know the Right Risk Budget?
 We recommend using the default linear risk budget, which is the shape *used in the paper*. This corresponds to \{shape_parameter\}$`= 0.0`$ for each shape family. Thus, *each of the following commands constructs the same policy*:
 

--- a/scripts/synthesize_general_step_policy.py
+++ b/scripts/synthesize_general_step_policy.py
@@ -481,7 +481,7 @@ if __name__ == "__main__":
         "-up",
         "--use_p_norm",
         type=str,
-        default=False,
+        default="False",
         help=(
             "Toggle whether to use p_norm or zeta function shape family for the risk budget. "
             "If True, uses p_norm shape; else, uses zeta function shape family. "

--- a/sequentialized_barnard_tests/step.py
+++ b/sequentialized_barnard_tests/step.py
@@ -10,8 +10,9 @@ URL: https://www.arxiv.org/abs/2503.10966
 
 import os
 import pickle
+import subprocess
+import sys
 import warnings
-from pathlib import Path
 from typing import Optional, Union
 
 import numpy as np
@@ -323,15 +324,10 @@ class StepTest(SequentialTestBase):
             verbose (bool, optional): If True, print the outputs to stdout.
                 Defaults to False.
         """
-        # print(str(Path(os.path.dirname(os.path.abspath(__file__))).resolve()))
-        # print(os.path.dirname(os.path.abspath(__file__)))
-        # print(os.path.dirname(__file__))
-        # self.policy_path = os.path.join(
-        #     str(
-        #         Path(os.path.dirname(os.path.abspath(__file__))).resolve()
-        #     ),  # os.path.dirname(os.path.abspath(__file__)),
-        #     f"policies/n_max_{self.n_max}_alpha_{self.alpha}_shape_parameter_{self.shape_parameter}_pnorm_{self.use_p_norm}/policy_compressed.pkl",
-        # )
+        # Determine the path to the synthesis script
+        script_dir = os.path.join(os.path.dirname(__file__), "..", "scripts")
+        synth_script = os.path.join(script_dir, "synthesize_general_step_policy.py")
+
         policy_path = os.path.join(
             os.path.dirname(__file__),
             f"policies/n_max_{self.n_max}_alpha_{self.alpha}_shape_parameter_{self.shape_parameter}_pnorm_{self.use_p_norm}/",
@@ -342,11 +338,41 @@ class StepTest(SequentialTestBase):
             with open(policy_path, "rb") as filename:
                 self.policy = pickle.load(filename)
             self.need_new_policy = False
-        except:
-            warnings.warn(
-                f"Current policy path: {policy_path}"
-                "Unable to find policy with the assigned test parameters. An additional policy synthesis procedure may be required."
-            )
+        except Exception as e:
+            print(f"Policy not found at {policy_path}. Attempting synthesis...")
+            # Build command to synthesize policy
+            cmd = [
+                sys.executable,
+                synth_script,
+                "--n_max",
+                str(self.n_max),
+                "--alpha",
+                str(self.alpha),
+                "--n_points",
+                "129",  # default value, could be parameterized
+                "--lambda_value",
+                "2.1",  # default, could be parameterized
+                "--major_axis_length",
+                "1.4",  # default, could be parameterized
+                "--log_p_norm",
+                str(self.shape_parameter),
+                "--use_p_norm",
+                str(self.use_p_norm),
+            ]
+            print(f"Running synthesis command: {' '.join(cmd)}")
+            result = subprocess.run(cmd, cwd=script_dir, capture_output=False)
+            # Try loading again
+            try:
+                with open(policy_path, "rb") as filename:
+                    self.policy = pickle.load(filename)
+                self.need_new_policy = False
+                print("Policy synthesis and loading successful.")
+            except Exception as e2:
+                warnings.warn(
+                    f"Unable to synthesize or load policy at {policy_path}. Error: {e2}"
+                )
+                self.policy = None
+                self.need_new_policy = True
 
         self.policy_path = policy_path
 


### PR DESCRIPTION
- Fixed a bug in the synthesis script, which yielded an error when `--use_p_norm` was missing.
- Using `subprocess` to automatically calls a policy synthesis script upon instantiation of a STEP test object.