### PR TITLE
Require statistical-comparison-core 0.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "numpy>=1.20",
         "pytest",
         "scipy",
-        "statistical-comparison-core",
+        "statistical-comparison-core>=0.2.0,<0.3",
         "statistical-comparison-helpers",
         "tqdm",
     ],


### PR DESCRIPTION
- Update the statistical-comparison-core dependency bound to require the mirrored wrapper-owned attribute contract introduced in 0.2.0.
- Keep the upper bound below 0.3 for the current integration surface.